### PR TITLE
Strip "List of Devices" when enumerating devices

### DIFF
--- a/lib/madb.rb
+++ b/lib/madb.rb
@@ -157,8 +157,9 @@ def adb_scan(verbose = false)
 
     outlines.each { |ln|
       ln.chomp!
+      ln.strip!
       next if ln.length < 1
-      next if ln == "List of devices attached "
+      next if ln == "List of devices attached"
 
       parts = ln.split("\t")
       serial = parts.first


### PR DESCRIPTION
I was getting the following in `lib/devices/pool.rb` in addition to my actual list of devices:

```
  {
    :name => 'name', # description
    :serial => 'List of devices attached',
  },
```
